### PR TITLE
Remove <> around URL

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 _Describe the purpose of the pull request_
 _Mention other relevant changes & include screenshots if they could help the review_
 
-<img src="https://hitta.myjetbrains.com/youtrack/static/favicon.ico" alt="YouTrack" width="15" height="15"> [YOUTRACK_SUBJECT](<YOUTRACK_URL>)
+<img src="https://hitta.myjetbrains.com/youtrack/static/favicon.ico" alt="YouTrack" width="15" height="15"> [YOUTRACK_SUBJECT](YOUTRACK_URL)
 
 ## Deploy notes
 _Examples: Environment variables, scripts or changes in dependencies_


### PR DESCRIPTION
## Description Problem, solution or enhancement
When double-clicking on `<YOUTRACK_URL>`, only the `YOUTRACK_URL` part is selected (at least on Safari/Mac).
This forces manual editing to remove `<` and `>`.

This PR fixes that annoyance by only keeping the text.

![image](https://user-images.githubusercontent.com/361840/99654644-e9087180-2a5a-11eb-9532-ed2cc9bb5d9c.png)

<img src="https://hitta.myjetbrains.com/youtrack/static/favicon.ico" alt="YouTrack" width="15" height="15"> 